### PR TITLE
Prevents default DataTables sorting. Also corrects pageLength setting to only limit when necessary.

### DIFF
--- a/gui/frontend/src/dashboard/dashboard.coffee
+++ b/gui/frontend/src/dashboard/dashboard.coffee
@@ -845,9 +845,14 @@ angular.module "mindbenderApp.dashboard", [
             scope.table = scope.report.data[attrs.file].table
             scope.bindToTask = taskArea.receiveValue if taskArea?
             $timeout ->
-                element.find("table").DataTable({
-                    pageLength: 25
-                })
+                options = {
+                    order: []
+                }
+
+                if scope.table.data.length > 25
+                    options.pageLength = 25
+
+                element.find("table").DataTable(options)
     }
 
 .directive 'mbTaskControl', ($timeout) ->


### PR DESCRIPTION
Fixes https://github.com/HazyResearch/mindbender/issues/22
